### PR TITLE
Used realpath due to weird error with chrome headless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+
+.idea/

--- a/src/HeadlessChrome.php
+++ b/src/HeadlessChrome.php
@@ -130,10 +130,10 @@ class HeadlessChrome {
      */
     public function setOutputDirectory($directory)
     {
-        $this->outputDirectory = trim($directory);
-        if (!file_exists($directory)) {
+        if (!file_exists($directory) || !realpath($directory)) {
             @mkdir($directory);
         }
+        $this->outputDirectory = realpath(trim($directory));
     }
 
 

--- a/tests/HeadlessChromeTestSuite.php
+++ b/tests/HeadlessChromeTestSuite.php
@@ -34,7 +34,7 @@ final class HeadlessChromeTestSuite extends TestCase{
     public function testSetOutputDirectory() {
         $headlessChromer = new HeadlessChrome();
         $headlessChromer->setOutputDirectory($this->ouputDirectory);
-        $this->assertEquals($this->ouputDirectory, $headlessChromer->getOutputDirectory());
+        $this->assertEquals(realpath($this->ouputDirectory), $headlessChromer->getOutputDirectory());
     }
 
 


### PR DESCRIPTION
Hi,

I added the following:
- Use realpath because of strange error with google-chrome headless when using dots in path.
- Updated test
- removed idea from repo and added to .gitignore

You can check this thing yourself using 
```
$ google-chrome --headless --disable-gpu --screenshot=/home/{whoami}/Documents/PHPHeadlessChrome/../data/screenshot.png https://www.chromestatus.com/
```
Will raise the following error **even when path exist**:
```error
[0309/171714.131329:ERROR:headless_shell.cc(536)] Writing to file /home/{whoami}/Documents/PHPHeadlessChrome/../data/screenshot.png was unsuccessful, could not open file: FILE_ERROR_ACCESS_DENIED
```

I don't know how this is on Windows as I'm not using it.