### PR TITLE
Unique name is not very unique!

### DIFF
--- a/src/HeadlessChrome.php
+++ b/src/HeadlessChrome.php
@@ -245,7 +245,7 @@ class HeadlessChrome
      */
     private function getUniqueName($extension)
     {
-        return md5(date('Y-m-d H:i:s:u')) . '.' . $extension;
+        return md5((new \DateTime())->format('Y-m-d H:i:s:u')) . '.' . $extension;
     }
 
 


### PR DESCRIPTION
The `date()` function always returns `000000` for microseconds according to the documentation https://www.php.net/manual/en/datetime.format.php
> Note that date() will always generate 000000 since it takes an int parameter, whereas DateTime::format() does support microseconds if DateTime was created with microseconds.

So `getUniqueName()` doesn't return a very unique name